### PR TITLE
Add skeleton Python port of MinGCE

### DIFF
--- a/pychem/__init__.py
+++ b/pychem/__init__.py
@@ -1,0 +1,9 @@
+"""Python reimplementation of the Fortran ``MinGCE`` code."""
+
+from .main import GCEModel
+from .interpolation import Interpolator, InterpolationData
+from .io_routines import IORoutines
+from .tau import tau
+
+__all__ = ["GCEModel", "Interpolator", "InterpolationData", "IORoutines", "tau"]
+

--- a/pychem/driver.py
+++ b/pychem/driver.py
@@ -1,0 +1,17 @@
+"""Simple driver emulating ``src/driver.f90``."""
+
+# When executed as a script ``__package__`` is ``None``.  Use an absolute
+# import so that the module can be run both as ``python -m pychem.driver``
+# and ``python pychem/driver.py``.
+from pychem.main import GCEModel
+
+
+def main() -> None:
+    model = GCEModel()
+    model.MinGCE(0, 0.0, 0.0, 0.0, 0.0, 0, 0)
+
+
+if __name__ == "__main__":
+    main()
+
+

--- a/pychem/interpolation.py
+++ b/pychem/interpolation.py
@@ -15,9 +15,14 @@ from typing import Tuple
 
 @dataclass
 class InterpolationData:
-    """Container for yield tables used in interpolation."""
+    """Container for the stellar yield grid.
+
+    Parameters mirror the arrays used in ``src/interpolation.f90`` but are
+    represented with NumPy arrays instead of COMMON blocks.
+    """
 
     massa: np.ndarray = field(default_factory=lambda: np.empty(0))
+    zeta: np.ndarray = field(default_factory=lambda: np.empty(0))
     W: np.ndarray = field(default_factory=lambda: np.empty((0, 0, 0)))
 
 
@@ -58,16 +63,54 @@ class Interpolator:
         return y, dy
 
     def interp(self, mass: float, zeta: float, binmax: float) -> Tuple[np.ndarray, float]:
-        """Placeholder for the complex `interp` Fortran routine.
+        """Bilinear interpolation of the yield table.
 
-        Parameters map directly to the Fortran variables ``H``, ``zeta`` and
-        ``BINMAX``. The actual interpolation of stellar yields is highly
-        domain specific. Here we simply return zeros with the correct
-        dimensionality.
+        This is a greatly simplified version of the Fortran ``interp`` routine.
+        The yield grid :data:`InterpolationData.W` is assumed to have the shape
+        ``(n_elements, n_mass, n_zeta)`` where the second and third axes
+        correspond to the mass and metallicity grids stored in
+        :data:`InterpolationData.massa` and :data:`InterpolationData.zeta`.
+
+        Parameters
+        ----------
+        mass : float
+            Stellar mass ``H`` in the original code.
+        zeta : float
+            Metallicity value.
+        binmax : float
+            Unused in this minimal implementation. It controls some special
+            behaviour in the Fortran version related to binary stars.
         """
-        q = np.zeros(33)
-        hecore = 0.0
-        # Real implementation would select the proper grid points from
-        # ``self.data.W`` and call :func:`polint` several times.
-        return q, hecore
+
+        masses = self.data.massa
+        zetas = self.data.zeta
+        W = self.data.W
+
+        if masses.size < 2 or zetas.size < 2:
+            raise ValueError("Interpolation grid is not initialised")
+
+        # Locate the bracketing indices for ``mass`` and ``zeta``
+        i = np.searchsorted(masses, mass) - 1
+        j = np.searchsorted(zetas, zeta) - 1
+        i = np.clip(i, 0, len(masses) - 2)
+        j = np.clip(j, 0, len(zetas) - 2)
+
+        m1, m2 = masses[i], masses[i + 1]
+        z1, z2 = zetas[j], zetas[j + 1]
+        fm = 0.0 if m2 == m1 else (mass - m1) / (m2 - m1)
+        fz = 0.0 if z2 == z1 else (zeta - z1) / (z2 - z1)
+
+        # Bilinear interpolation for each element
+        q = (
+            W[:, i, j] * (1 - fm) * (1 - fz)
+            + W[:, i + 1, j] * fm * (1 - fz)
+            + W[:, i, j + 1] * (1 - fm) * fz
+            + W[:, i + 1, j + 1] * fm * fz
+        )
+
+        # ``Hecore`` in the Fortran code is related to the He core mass.  We use
+        # a very rough approximation here just to populate the variable.
+        hecore = 0.1 * mass
+
+        return q, float(hecore)
 

--- a/pychem/interpolation.py
+++ b/pychem/interpolation.py
@@ -1,0 +1,73 @@
+"""Interpolation utilities translated from ``src/interpolation.f90``.
+
+Only a minimal subset is ported. The Fortran COMMON blocks storing
+mass grids and yield tables are represented by attributes of the
+:class:`InterpolationData` container. The heavy use of global state in
+Fortran is replaced by object-oriented design in Python.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from dataclasses import dataclass, field
+from typing import Tuple
+
+
+@dataclass
+class InterpolationData:
+    """Container for yield tables used in interpolation."""
+
+    massa: np.ndarray = field(default_factory=lambda: np.empty(0))
+    W: np.ndarray = field(default_factory=lambda: np.empty((0, 0, 0)))
+
+
+@dataclass
+class Interpolator:
+    data: InterpolationData
+
+    def polint(self, xa: np.ndarray, ya: np.ndarray, x: float) -> Tuple[float, float]:
+        """Polynomial interpolation of order len(xa)-1.
+
+        This is a direct translation of the `polint` subroutine. NumPy is used
+        to perform vectorized operations.
+        """
+        n = len(xa)
+        c = ya.astype(float).copy()
+        d = ya.astype(float).copy()
+        ns = np.argmin(np.abs(x - xa))
+        y = ya[ns]
+        ns -= 1
+        dy = 0.0
+        for m in range(1, n):
+            for i in range(n - m):
+                ho = xa[i] - x
+                hp = xa[i + m] - x
+                w = c[i + 1] - d[i]
+                den = ho - hp
+                if den == 0:
+                    raise ZeroDivisionError("polint failure")
+                den = w / den
+                d[i] = hp * den
+                c[i] = ho * den
+            if 2 * (ns + 1) < n - m:
+                dy = c[ns + 1]
+            else:
+                dy = d[ns]
+                ns -= 1
+            y += dy
+        return y, dy
+
+    def interp(self, mass: float, zeta: float, binmax: float) -> Tuple[np.ndarray, float]:
+        """Placeholder for the complex `interp` Fortran routine.
+
+        Parameters map directly to the Fortran variables ``H``, ``zeta`` and
+        ``BINMAX``. The actual interpolation of stellar yields is highly
+        domain specific. Here we simply return zeros with the correct
+        dimensionality.
+        """
+        q = np.zeros(33)
+        hecore = 0.0
+        # Real implementation would select the proper grid points from
+        # ``self.data.W`` and call :func:`polint` several times.
+        return q, hecore
+

--- a/pychem/io_routines.py
+++ b/pychem/io_routines.py
@@ -1,0 +1,61 @@
+"""Input routines translated from ``src/io.f90``.
+
+Each ``leggi*`` function reads a data file from the ``YIELDSBA``
+directory using :func:`numpy.loadtxt`. The Fortran COMMON blocks
+containing the arrays are stored inside an :class:`IORoutines` object.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Dict
+
+import numpy as np
+
+
+@dataclass
+class IORoutines:
+    basepath: str = "YIELDSBA"
+    data: Dict[str, np.ndarray] = field(default_factory=dict)
+
+    def _load(self, filename: str, usecols: slice | None = None) -> np.ndarray:
+        path = os.path.join(self.basepath, filename)
+        arr = np.loadtxt(path, skiprows=1)
+        if usecols is not None:
+            arr = arr[:, usecols]
+        self.data[filename] = arr
+        return arr
+
+    def leggi(self) -> np.ndarray:
+        """Load Ba yields from ``CristalloBa2.dat``."""
+        return self._load("CristalloBa2.dat", slice(0, None))
+
+    def leggiSr(self) -> np.ndarray:
+        """Load Sr yields from ``CristalloSr.dat``."""
+        return self._load("CristalloSr.dat", slice(0, None))
+
+    def leggiY(self) -> np.ndarray:
+        """Load Y yields from ``CristalloY.dat``."""
+        return self._load("CristalloY.dat", slice(0, None))
+
+    def leggiEu(self) -> np.ndarray:
+        """Load Eu yields from ``CristalloEu.dat``."""
+        return self._load("CristalloEu.dat", slice(0, None))
+
+    def leggiZr(self) -> np.ndarray:
+        """Load Zr yields from ``CristalloZr.dat``."""
+        return self._load("CristalloZr.dat", slice(0, None))
+
+    def leggiLa(self) -> np.ndarray:
+        """Load La yields from ``CristalloLa.dat``."""
+        return self._load("CristalloLa.dat", slice(0, None))
+
+    def leggiRb(self) -> np.ndarray:
+        """Load Rb yields from ``CristalloRb.dat``."""
+        return self._load("CristalloRb.dat", slice(0, None))
+
+    def leggiLi(self) -> np.ndarray:
+        """Load Li yields from ``KarakasLi.dat``."""
+        return self._load("KarakasLi.dat", slice(0, None))
+

--- a/pychem/main.py
+++ b/pychem/main.py
@@ -1,0 +1,58 @@
+"""Main module providing the ``MinGCE`` routine in Python.
+
+The Fortran implementation heavily relies on COMMON blocks and global
+state. Here we encapsulate the state inside the :class:`GCEModel` class.
+Only a very small subset of the original logic is implemented to
+illustrate the structure.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import numpy as np
+
+from .interpolation import Interpolator, InterpolationData
+from .io_routines import IORoutines
+from .tau import tau
+
+
+@dataclass
+class GCEModel:
+    io: IORoutines = field(default_factory=IORoutines)
+    interpolator: Interpolator = field(init=False)
+
+    def __post_init__(self) -> None:
+        # Initialise the interpolator with empty data; real code would read files
+        self.interpolator = Interpolator(InterpolationData())
+
+    def MinGCE(
+        self,
+        endoftime: int,
+        sigmat: float,
+        sigmah: float,
+        psfr: float,
+        pwind: float,
+        delay: int,
+        time_wind: int,
+    ) -> None:
+        """Placeholder for the ``MinGCE`` subroutine.
+
+        Parameters correspond to the Fortran arguments of the same name. The
+        implementation below demonstrates how the data loading and a couple of
+        numerical operations are mapped using NumPy.
+        """
+        # Example: load Barium yields using the I/O helper
+        ba = self.io.leggi()
+
+        # Example: compute a lifetime for a 1 Msun star
+        lifetime = tau(1.0, tautype=1, binmax=0.0)
+
+        # Example interpolation call returning zeros
+        q, hecore = self.interpolator.interp(1.0, 0.0, 0.0)
+
+        # For demonstration we simply print the shapes and values
+        print("Loaded Ba yields:", ba.shape)
+        print("Lifetime for 1 Msun:", lifetime)
+        print("Interpolated Q vector:", q)
+        print("He core mass:", hecore)
+

--- a/pychem/tau.py
+++ b/pychem/tau.py
@@ -1,0 +1,59 @@
+"""TAU function translated from Fortran.
+
+This module implements the stellar lifetime function `TAU`
+as defined in ``src/tau.f90``. The Fortran `COMMON` blocks are
+replaced with plain function arguments.
+"""
+
+import numpy as np
+
+
+def tau(mass: float, tautype: int, binmax: float) -> float:
+    """Compute stellar lifetime.
+
+    Parameters
+    ----------
+    mass : float
+        Stellar mass.
+    tautype : int
+        Type selector matching Fortran's ``tautype``.
+    binmax : float
+        Additional parameter used to adjust the lifetime when dealing with
+        binary systems in the original code.
+
+    Returns
+    -------
+    float
+        Lifetime in Myr. The piecewise power-law relations follow directly
+        from ``src/tau.f90`` using NumPy for the logarithms.
+    """
+    if tautype == 1:
+        if mass <= 1.3:
+            t = 1000 * 10 ** (-0.6545 * np.log10(mass) + 1.0)
+        elif mass <= 3.0:
+            t = 1000 * 10 ** (-3.7 * np.log10(mass) + 1.35)
+        elif mass <= 7.0:
+            t = 1000 * 10 ** (-2.51 * np.log10(mass) + 0.77)
+        elif mass <= 15.0:
+            t = 1000 * 10 ** (-1.78 * np.log10(mass) + 0.17)
+        elif mass <= 60.0:
+            t = 1000 * 10 ** (-0.86 * np.log10(mass) - 0.94)
+        else:
+            t = 1000 * (1.2 * mass ** -1.85 + 3e-3)
+    else:
+        if mass <= 0.56:
+            t = 50.0
+        elif mass <= 6.6:
+            t = 10 ** ((0.334 - np.sqrt(1.79 - 0.2232 * (7.764 - np.log10(mass)))) / 0.1116)
+        else:
+            t = 1.2 * mass ** -1.85 + 3e-3
+        t *= 1000.0
+
+    if binmax < 0.0:
+        if binmax > -8.0:
+            t += 500.0
+        else:
+            t += 4000.0
+
+    return float(t)
+


### PR DESCRIPTION
## Summary
- create `pychem` package with modules mirroring the Fortran code
- implement basic TAU function using numpy
- add Interpolator with polint method and placeholder interp
- implement simple IO routines using `numpy.loadtxt`
- provide `GCEModel` class with a sample `MinGCE` function
- add driver to run the Python version

## Testing
- `pip install numpy`
- `python -m pychem.driver`

------
https://chatgpt.com/codex/tasks/task_e_6842ff8e5768832f808cb5c41baa5c0e