### PR TITLE
Add python build target using f2py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,24 @@
 FC = gfortran
 FFLAGS = -O2 -ffixed-form -I.
 
-# Source files ordered to satisfy module dependencies
+# Run ``make`` to build the standalone executable ``GCE_min.x``.
+# ``make python`` compiles the Fortran sources into ``gce.so`` using f2py.
+
+# Fortran source files used by both the executable and the Python module
+# ``SRC`` intentionally excludes ``src/driver.f90`` which is only required
+# for the standalone executable.  The same list is reused by the ``python``
+# target defined below.
 SRC = \
 src/io.f90 \
 src/interpolation.f90 \
 src/tau.f90 \
-src/main.f90 \
-src/driver.f90
+src/main.f90
 
-# Objects compiled in the same order as SRC
-OBJ = $(SRC:.f90=.o)
+# Additional source only for the standalone program
+DRIVER = src/driver.f90
+
+# Objects compiled in the same order as the source files
+OBJ = $(SRC:.f90=.o) $(DRIVER:.f90=.o)
 
 all: GCE_min.x
 
@@ -24,5 +32,16 @@ src/driver.o: src/main.o src/interpolation.o src/io.o
 GCE_min.x: $(OBJ) Makefile
 	$(FC) $(FFLAGS) -o $@ $(OBJ)
 
+PY_SRC = src/main.f90 src/interpolation.f90 src/io.f90 src/tau.f90
+PY_MOD = gce
+
+# Build the Fortran sources into a Python extension using ``f2py``. This
+# produces ``gce.so`` which exposes the legacy routines to Python.
+$(PY_MOD).so: $(PY_SRC)
+	f2py -c --fcompiler=gfortran -m $(PY_MOD) $(PY_SRC)
+
+# Alias so ``make python`` will produce the module
+python: $(PY_MOD).so
+
 clean:
-	rm -f $(OBJ) GCE_min.x
+	rm -f $(OBJ) GCE_min.x $(PY_MOD).so

--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ make
 ./GCE_min.x
 ```
 
+To compile the same sources into a Python module using `f2py` you can run:
+
+```bash
+make python
+```
+This produces `gce.so` which exposes the Fortran routines to Python.
+
 ## Repository layout
 
 ```


### PR DESCRIPTION
## Summary
- exclude driver from common SRC list and add DRIVER variable
- add new `python` target that compiles a `gce.so` module using f2py
- document the python build option in Makefile and README

## Testing
- `make -n`
- `make -n python`
- `make python` *(fails: f2py not found)*
- `make` *(fails: gfortran not found)*
- `make clean`

------
https://chatgpt.com/codex/tasks/task_e_6843def7f9b8832fa3c489e8cd413f58