### PR TITLE
Fix pycodestyle warnings in pychem modules

### DIFF
--- a/pychem/__init__.py
+++ b/pychem/__init__.py
@@ -5,5 +5,10 @@ from .interpolation import Interpolator, InterpolationData
 from .io_routines import IORoutines
 from .tau import tau
 
-__all__ = ["GCEModel", "Interpolator", "InterpolationData", "IORoutines", "tau"]
-
+__all__ = [
+    "GCEModel",
+    "Interpolator",
+    "InterpolationData",
+    "IORoutines",
+    "tau",
+]

--- a/pychem/driver.py
+++ b/pychem/driver.py
@@ -13,5 +13,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-
-

--- a/pychem/interpolation.py
+++ b/pychem/interpolation.py
@@ -30,7 +30,9 @@ class InterpolationData:
 class Interpolator:
     data: InterpolationData
 
-    def polint(self, xa: np.ndarray, ya: np.ndarray, x: float) -> Tuple[float, float]:
+    def polint(
+        self, xa: np.ndarray, ya: np.ndarray, x: float
+    ) -> Tuple[float, float]:
         """Polynomial interpolation of order len(xa)-1.
 
         This is a direct translation of the `polint` subroutine. NumPy is used
@@ -62,7 +64,9 @@ class Interpolator:
             y += dy
         return y, dy
 
-    def interp(self, mass: float, zeta: float, binmax: float) -> Tuple[np.ndarray, float]:
+    def interp(
+        self, mass: float, zeta: float, binmax: float
+    ) -> Tuple[np.ndarray, float]:
         """Bilinear interpolation of the yield table.
 
         This is a greatly simplified version of the Fortran ``interp`` routine.
@@ -108,9 +112,9 @@ class Interpolator:
             + W[:, i + 1, j + 1] * fm * fz
         )
 
-        # ``Hecore`` in the Fortran code is related to the He core mass.  We use
-        # a very rough approximation here just to populate the variable.
+        # ``Hecore`` in the Fortran code is related to the He core mass.
+        # We use a very rough approximation here just to populate the
+        # variable.
         hecore = 0.1 * mass
 
         return q, float(hecore)
-

--- a/pychem/io_routines.py
+++ b/pychem/io_routines.py
@@ -64,7 +64,9 @@ class IORoutines:
     # ------------------------------------------------------------------
     # Additional helpers ------------------------------------------------
 
-    def load_yield_grid(self, filenames: list[str], basepath: str = "DATI") -> "InterpolationData":
+    def load_yield_grid(
+        self, filenames: list[str], basepath: str = "DATI"
+    ) -> "InterpolationData":
         """Read a set of yield tables forming a mass/metallicity grid.
 
         Parameters
@@ -92,7 +94,9 @@ class IORoutines:
                 if "=" in first:
                     zetas.append(float(first.split("=")[1]))
                 else:
-                    raise ValueError(f"Could not parse metallicity from {fname}")
+                    raise ValueError(
+                        f"Could not parse metallicity from {fname}"
+                    )
             arr = np.loadtxt(path, skiprows=2)
             masses = arr[:, 0]
             yields = arr[:, 1:].T  # elements x mass
@@ -105,4 +109,3 @@ class IORoutines:
 
         W = np.stack(tables, axis=2)
         return InterpolationData(massa=mass_grid, zeta=np.array(zetas), W=W)
-

--- a/pychem/main.py
+++ b/pychem/main.py
@@ -63,4 +63,3 @@ class GCEModel:
         print("Lifetime for 5 Msun:", lifetime)
         print("Interpolated Q vector (first 5):", q[:5])
         print("He core mass:", hecore)
-

--- a/pychem/tau.py
+++ b/pychem/tau.py
@@ -44,7 +44,13 @@ def tau(mass: float, tautype: int, binmax: float) -> float:
         if mass <= 0.56:
             t = 50.0
         elif mass <= 6.6:
-            t = 10 ** ((0.334 - np.sqrt(1.79 - 0.2232 * (7.764 - np.log10(mass)))) / 0.1116)
+            t = 10 ** (
+                (
+                    0.334
+                    - np.sqrt(1.79 - 0.2232 * (7.764 - np.log10(mass)))
+                )
+                / 0.1116
+            )
         else:
             t = 1.2 * mass ** -1.85 + 3e-3
         t *= 1000.0
@@ -56,4 +62,3 @@ def tau(mass: float, tautype: int, binmax: float) -> float:
             t += 4000.0
 
     return float(t)
-


### PR DESCRIPTION
## Summary
- fix line length and trailing blank lines to conform to pycodestyle

## Testing
- `python -m pycodestyle pychem`

------
https://chatgpt.com/codex/tasks/task_e_684b48ddd068832fb707ea8f5351e40c