### PR TITLE
Refactor path management for io routines

### DIFF
--- a/pychem/io_routines.py
+++ b/pychem/io_routines.py
@@ -7,22 +7,25 @@ containing the arrays are stored inside an :class:`IORoutines` object.
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict
 
 import numpy as np
 
+BASE_DIR = Path(__file__).resolve().parent.parent
+
 
 @dataclass
 class IORoutines:
-    basepath: str = "YIELDSBA"
     data: Dict[str, np.ndarray] = field(default_factory=dict)
+    basepath: Path = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.basepath = BASE_DIR / "YIELDSBA"
 
     def _load(self, filename: str, usecols: slice | None = None) -> np.ndarray:
-        base = Path(__file__).resolve().parent / ".."
-        path = base / self.basepath / filename
+        path = self.basepath / filename
         arr = np.loadtxt(path, skiprows=1)
         if usecols is not None:
             arr = arr[:, usecols]
@@ -79,14 +82,12 @@ class IORoutines:
 
         from .interpolation import InterpolationData
 
-        base = Path(__file__).resolve().parent / ".."
-
         mass_grid = None
         tables = []
         zetas = []
 
         for fname in filenames:
-            path = base / basepath / fname
+            path = BASE_DIR / basepath / fname
             with open(path, "r") as fh:
                 first = fh.readline()
                 if "=" in first:


### PR DESCRIPTION
## Summary
- centralize repository root path as `BASE_DIR`
- use `BASE_DIR` within `_load` and `load_yield_grid`
- store heavy-element basepath on `IORoutines`

## Testing
- `pytest -q`
- `python -m pychem.driver`

------
https://chatgpt.com/codex/tasks/task_e_684b48dadf80832fbe2d54ff79b1b333