### PR TITLE
Remove unused os import

### DIFF
--- a/pychem/io_routines.py
+++ b/pychem/io_routines.py
@@ -7,7 +7,6 @@ containing the arrays are stored inside an :class:`IORoutines` object.
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict


### PR DESCRIPTION
## Summary
- delete the unused `os` import from `pychem/io_routines.py`

## Testing
- `python -m py_compile pychem/io_routines.py`


------
https://chatgpt.com/codex/tasks/task_e_684b48d70e9c832fa6ce42bbdf26176d