### PR TITLE
Add python and fortran artifacts to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,12 +3,14 @@
 
 # Shared libraries
 *.so
+*.mod
 
 # Executable output
 GCE_min.x
 
 # Python cache directories
 __pycache__/
+*.pyc
 
 # Temporary build directories
 build/


### PR DESCRIPTION
## Summary
- ignore Python cache files and Fortran build outputs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b48d523ec832f9bc3e84bbd634c09