### PR TITLE
Fix f2py build with Python 3.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ PY_MOD = gce
 # produces ``gce.so`` which exposes the legacy routines to Python.
 
 $(PY_MOD).so: $(PY_SRC)
-	f2py -c --fcompiler=gfortran --f90flags="-ffixed-form -ffixed-line-length-none -fdollar-ok -I$(CURDIR)" -m $(PY_MOD) $(PY_SRC)
+	FC=gfortran f2py -c --f90flags="-ffixed-form -ffixed-line-length-none -fdollar-ok -I$(CURDIR)" -m $(PY_MOD) $(PY_SRC)
 
 # Alias so ``make python`` will produce the module
 python: $(PY_MOD).so

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ resources.
 
 * Python 3.10+
 * `numpy`
-* (optional) `gfortran` to build the original Fortran code
+* `gfortran` to build the original Fortran code
+* `meson` (required by `f2py` on Python 3.12+)
 
 Install the Python dependencies using `pip`:
 
@@ -74,6 +75,13 @@ To compile the same sources into a Python module using `f2py` you can run:
 make python
 ```
 This produces `gce.so` which exposes the Fortran routines to Python.
+Building with Python 3.12 requires the external `meson` build
+system in addition to `gfortran`. Install the prerequisites with
+
+```bash
+sudo apt-get install gfortran
+pip install meson
+```
 
 ## Repository layout
 

--- a/src/driver.f90
+++ b/src/driver.f90
@@ -2,6 +2,7 @@
       use main_mod
       use interpolation_mod
       use io_mod
+      use io_aux_mod
       implicit none
       call MinGCE(0,0.0,0.0,0.0,0.0,0,0)
       end program GCE_run

--- a/src/io.f90
+++ b/src/io.f90
@@ -107,6 +107,10 @@ c
       return
       end
 
+      end module io_mod
+
+      module io_aux_mod
+      contains
 
       subroutine leggiZr
       implicit none
@@ -210,4 +214,4 @@ c
       return
       end
 
-       end module io_mod
+       end module io_aux_mod

--- a/src/main.f90
+++ b/src/main.f90
@@ -5,6 +5,7 @@
      &     delay,time_wind)
       
       use io_mod
+      use io_aux_mod
       use interpolation_mod
       implicit none
       integer nmax,elem


### PR DESCRIPTION
## Summary
- split `io_mod` into two modules so wrapper generator stays below line length limits
- update makefile to build with gfortran
- document meson requirement and install steps

## Testing
- `pytest -q`
- `make python`

------
https://chatgpt.com/codex/tasks/task_e_684b48dfcf44832fa61b78c146eb5308